### PR TITLE
Add miniblog visibility

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -46,6 +46,8 @@ func InitConfig() {
 		&models.BlogPost{},
 		&models.User{},
 	)
+	// Run migration queries
+	db.Exec("UPDATE blog_posts SET visibility = 0 WHERE visibility IS NULL")
 }
 
 func GetConfig() Config {

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -11,8 +11,6 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/session"
 	"github.com/gofiber/storage/sqlite3"
 	_ "github.com/joho/godotenv/autoload"
-	"github.com/markbates/goth"
-	"github.com/markbates/goth/providers/mastodon"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -59,16 +57,6 @@ func GetConfig() Config {
 	if err != nil {
 		log.Fatal(fmt.Sprintf("Cannot open %s", os.Getenv("DATABASE_PATH")), "err", err)
 	}
-
-	goth.UseProviders(
-		mastodon.NewCustomisedURL(
-			os.Getenv("OAUTH2_CLIENT_ID"),
-			os.Getenv("OAUTH2_CLIENT_SECRET"),
-			fmt.Sprintf("%s/auth/mastodon/callback", os.Getenv("APP_BASE_URL")),
-			fmt.Sprintf("%s", os.Getenv("MASTODON_URL")),
-			"read:accounts",
-		),
-	)
 
 	session := session.New(
 		session.Config{

--- a/app/handlers/miniblog.go
+++ b/app/handlers/miniblog.go
@@ -54,6 +54,10 @@ func GetMiniblogNew(c *fiber.Ctx) error {
 	config := config.GetConfig()
 	mastodonAccount := models.GetUserMastodonFromSession(config.Storage.Session, c)
 
+	if mastodonAccount.UserID == "" {
+		return c.Redirect("/miniblog/")
+	}
+
 	params := fiber.Map{}
 	params["mastodonAccount"] = mastodonAccount
 	params["visibilityOptions"] = models.BlogPostVisibilityOptions()

--- a/app/handlers/miniblog.go
+++ b/app/handlers/miniblog.go
@@ -265,6 +265,7 @@ func postToMastodon(mUser goth.User, post models.BlogPost) {
 		&mastodon.Toot{
 			Status:     statusTxt,
 			Visibility: strings.ToLower(post.Visibility.String()),
+			Language:   "EN",
 		},
 	)
 	if err != nil {

--- a/app/handlers/miniblog.go
+++ b/app/handlers/miniblog.go
@@ -137,6 +137,7 @@ func GetMiniblogByUsernamePostsPostEdit(c *fiber.Ctx) error {
 	params["User"] = blogPost.User
 	params["Post"] = blogPost
 	params["mastodonAccount"] = mastodonAccount
+	params["visibilityOptions"] = models.BlogPostVisibilityOptions()
 
 	c.Render("miniblog/posts/update", params)
 	return nil
@@ -146,6 +147,10 @@ func PostMiniblogByUsernamePostsPostEdit(c *fiber.Ctx) error {
 	config := config.GetConfig()
 	mastodonAccount := models.GetUserMastodonFromSession(config.Storage.Session, c)
 	postId := c.Params("post")
+	visibility, err := strconv.Atoi(c.FormValue("visibility"))
+	if err != nil {
+		log.Fatal("Could not parse visibility value", "visibility", visibility, "err", err)
+	}
 
 	var blogPost models.BlogPost
 	config.Storage.Database.Preload("User").First(&blogPost, "id = ?", postId)
@@ -157,8 +162,9 @@ func PostMiniblogByUsernamePostsPostEdit(c *fiber.Ctx) error {
 
 	blogPost.Body = c.FormValue("body")
 	blogPost.Title = c.FormValue("title")
+	blogPost.Visibility = models.BlogPostVisibility(visibility)
 
-	err := saveBlogPost(config.Storage.Database, blogPost)
+	err = saveBlogPost(config.Storage.Database, blogPost)
 	if err != nil {
 		panic(err)
 	}

--- a/app/handlers/miniblog.go
+++ b/app/handlers/miniblog.go
@@ -5,6 +5,7 @@ import (
 	"mastodon-services/app/config"
 	"mastodon-services/app/models"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,9 +26,20 @@ func GetMiniblog(c *fiber.Ctx) error {
 	var latestPosts []models.BlogPost
 
 	config.Storage.Database.First(&user, models.User{ID: mastodonAccount.UserID})
-	config.Storage.Database.Preload("User").Order("created_at desc").Limit(20).Where("user_id = ?", mastodonAccount.UserID).Find(&blogPosts)
+	config.Storage.Database.
+		Preload("User").
+		Order("created_at desc").
+		Limit(20).
+		Where("user_id = ?", mastodonAccount.UserID).
+		Find(&blogPosts)
 
-	config.Storage.Database.Preload("User").Order("created_at desc").Limit(20).Where("user_id != ?", mastodonAccount.UserID).Find(&latestPosts)
+	config.Storage.Database.
+		Preload("User").
+		Order("created_at desc").
+		Limit(20).
+		Where("user_id != ?", mastodonAccount.UserID).
+		Where("visibility == ?", models.BlogPostVisibilityPublic).
+		Find(&latestPosts)
 
 	params := fiber.Map{}
 	params["mastodonAccount"] = mastodonAccount
@@ -43,10 +55,9 @@ func GetMiniblogNew(c *fiber.Ctx) error {
 	mastodonAccount := models.GetUserMastodonFromSession(config.Storage.Session, c)
 
 	params := fiber.Map{}
-	if mastodonAccount.UserID != "" {
-		params["mastodonAccount"] = mastodonAccount
-		params["Title"] = "Miniblog"
-	}
+	params["mastodonAccount"] = mastodonAccount
+	params["visibilityOptions"] = models.BlogPostVisibilityOptions()
+	params["Title"] = "Miniblog"
 	c.Render("miniblog/new", params)
 	return nil
 }
@@ -193,6 +204,11 @@ func PostMiniblog(c *fiber.Ctx) error {
 	config := config.GetConfig()
 	mastodonAccount := models.GetUserMastodonFromSession(config.Storage.Session, c)
 
+	visibility, err := strconv.Atoi(c.FormValue("visibility"))
+	if err != nil {
+		log.Fatal("Could not parse visibility value", "visibility", visibility, "err", err)
+	}
+
 	blogPost := models.BlogPost{
 		ID: uuid.New().String(),
 		User: models.User{
@@ -203,10 +219,11 @@ func PostMiniblog(c *fiber.Ctx) error {
 		},
 		Title:        c.FormValue("title"),
 		Body:         c.FormValue("body"),
+		Visibility:   models.BlogPostVisibility(visibility),
 		CreationDate: time.Now(),
 	}
 
-	err := saveBlogPost(config.Storage.Database, blogPost)
+	err = saveBlogPost(config.Storage.Database, blogPost)
 	if err != nil {
 		panic(err)
 	}

--- a/app/models/blog.go
+++ b/app/models/blog.go
@@ -12,6 +12,21 @@ import (
 	"gorm.io/gorm"
 )
 
+type BlogPostVisibility int
+type BlogPostVisibilityOption struct {
+	ID   int
+	Name string
+}
+
+const (
+	// Update BlogPostVisibility.String() accordingly
+	BlogPostVisibilityPublic BlogPostVisibility = iota
+	BlogPostVisibilityUnlisted
+	BlogPostVisibilityPrivate
+	BlogPostVisibilityDirect
+	BlogPostVisibilityLimited
+)
+
 type BlogPost struct {
 	gorm.Model
 	ID           string
@@ -19,7 +34,20 @@ type BlogPost struct {
 	User         User
 	Title        string
 	Body         string
+	Visibility   BlogPostVisibility `gorm:"not null;default:0"`
 	CreationDate time.Time
+}
+
+func (bpv BlogPostVisibility) String() string {
+	return []string{"Public", "Unlisted", "Private", "Direct", "Limited"}[bpv]
+}
+
+func BlogPostVisibilityOptions() []BlogPostVisibilityOption {
+	return []BlogPostVisibilityOption{
+		{ID: int(BlogPostVisibilityPublic), Name: BlogPostVisibilityPublic.String()},
+		{ID: int(BlogPostVisibilityUnlisted), Name: BlogPostVisibilityUnlisted.String()},
+		{ID: int(BlogPostVisibilityPrivate), Name: BlogPostVisibilityPrivate.String()},
+	}
 }
 
 func (b BlogPost) PreviewHTML() template.HTML {

--- a/app/models/blog.go
+++ b/app/models/blog.go
@@ -44,6 +44,10 @@ func (bpv BlogPostVisibility) String() string {
 	return []string{"Public", "Unlisted", "Private", "Direct", "Limited"}[bpv]
 }
 
+func (bpv BlogPostVisibility) ID() int {
+	return int(bpv)
+}
+
 func BlogPostVisibilityOptions() []BlogPostVisibilityOption {
 	return []BlogPostVisibilityOption{
 		{ID: int(BlogPostVisibilityPublic), Name: BlogPostVisibilityPublic.String()},

--- a/app/models/blog.go
+++ b/app/models/blog.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"fmt"
 	"html/template"
+	"os"
 	"strings"
 	"time"
 
@@ -60,6 +62,10 @@ func (b BlogPost) PreviewHTML() template.HTML {
 
 func (b BlogPost) ToHTML() template.HTML {
 	return template.HTML(string(mdToHTML([]byte(b.Body))))
+}
+
+func (b BlogPost) URL() string {
+	return fmt.Sprintf("%s/miniblog/%s/posts/%s", os.Getenv("APP_BASE_URL"), b.User.NickNameURL, b.ID)
 }
 
 func truncateText(s string, max int) string {

--- a/app/views/miniblog/new.html
+++ b/app/views/miniblog/new.html
@@ -9,6 +9,14 @@
         <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="body">Content (markdown compatible)</label>
         <textarea class="focus:shadow-outline w-full appearance-none rounded border px-3 py-2 leading-tight text-gray-700 shadow focus:outline-none" rows="12" id="body" name="body" placeholder="Your awesome thought..."></textarea>
       </div>
+      <div class="mb-4">
+        <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="visibility">Visibility</label>
+        <select name="visibility" id="visibility">
+          {{ range .visibilityOptions }}
+          <option value="{{ .ID }}">{{ .Name }}</option>
+          {{ end }}
+        </select>
+      </div>
       <div class="flex items-center justify-between">
         <button class="rounded-md bg-amber-500 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-amber-400 focus:outline-none dark:text-slate-900" type="submit">Share</button>
       </div>

--- a/app/views/miniblog/new.html
+++ b/app/views/miniblog/new.html
@@ -17,6 +17,10 @@
           {{ end }}
         </select>
       </div>
+      <div class="mb-4">
+        <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="publish_status">Publish on Mastodon?</label>
+        <input type="checkbox" id="publish_status" name="publish_status" checked />
+      </div>
       <div class="flex items-center justify-between">
         <button class="rounded-md bg-amber-500 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-amber-400 focus:outline-none dark:text-slate-900" type="submit">Share</button>
       </div>

--- a/app/views/miniblog/new.html
+++ b/app/views/miniblog/new.html
@@ -1,4 +1,4 @@
-<div class="relative rounded-xl bg-white p-8 drop-shadow dark:bg-slate-900">
+<div class="relative -mx-4 bg-white drop-shadow dark:bg-slate-900 md:rounded-xl md:p-8">
   <div class="w-full">
     <form class="mb-4 px-8 pb-8 pt-6" action="/miniblog" method="post">
       <div class="mb-4">
@@ -9,17 +9,19 @@
         <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="body">Content (markdown compatible)</label>
         <textarea class="focus:shadow-outline w-full appearance-none rounded border px-3 py-2 leading-tight text-gray-700 shadow focus:outline-none" rows="12" id="body" name="body" placeholder="Your awesome thought..."></textarea>
       </div>
-      <div class="mb-4">
-        <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="visibility">Visibility</label>
-        <select name="visibility" id="visibility">
-          {{ range .visibilityOptions }}
-          <option value="{{ .ID }}">{{ .Name }}</option>
-          {{ end }}
-        </select>
-      </div>
-      <div class="mb-4">
-        <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="publish_status">Publish on Mastodon?</label>
-        <input type="checkbox" id="publish_status" name="publish_status" checked />
+      <div class="flex">
+        <div class="mb-4 w-1/2">
+          <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="visibility">Visibility</label>
+          <select name="visibility" id="visibility">
+            {{ range .visibilityOptions }}
+            <option value="{{ .ID }}">{{ .Name }}</option>
+            {{ end }}
+          </select>
+        </div>
+        <div class="mb-4 w-1/2">
+          <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="publish_status">Publish on Mastodon?</label>
+          <input type="checkbox" id="publish_status" name="publish_status" checked />
+        </div>
       </div>
       <div class="flex items-center justify-between">
         <button class="rounded-md bg-amber-500 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-amber-400 focus:outline-none dark:text-slate-900" type="submit">Share</button>

--- a/app/views/miniblog/posts/show.html
+++ b/app/views/miniblog/posts/show.html
@@ -23,12 +23,16 @@
         {{ end }}
         <div class="my-4 flex w-full flex-col">
           <span class="text-md font-medium text-slate-500 dark:text-slate-400">
-            <strong class="font-bold text-slate-900 dark:text-slate-200">Published on: </strong>
+            <strong class="font-bold text-slate-900 dark:text-slate-200">Published on:</strong>
             {{ .Post.CreatedAt.Format "Jan 02, 2006" }}
           </span>
           <span class="text-md font-medium text-slate-500 dark:text-slate-400">
-            <strong class="font-bold text-slate-900 dark:text-slate-200">Updated on: </strong>
+            <strong class="font-bold text-slate-900 dark:text-slate-200">Updated on:</strong>
             {{ .Post.UpdatedAt.Format "Jan 02, 2006" }}
+          </span>
+          <span class="text-md font-medium text-slate-500 dark:text-slate-400">
+            <strong class="font-bold text-slate-900 dark:text-slate-200">Visibility:</strong>
+            {{ .Post.Visibility.String }}
           </span>
         </div>
       </div>

--- a/app/views/miniblog/posts/update.html
+++ b/app/views/miniblog/posts/update.html
@@ -17,7 +17,7 @@
           <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="visibility">Visibility</label>
           <select name="visibility" id="visibility">
             {{ range .visibilityOptions }}
-            <option value="{{ .ID }}">{{ .Name }}</option>
+            <option value="{{ .ID }}" {{ if eq $.Post.Visibility.ID .ID }} selected {{ end }}>{{ .Name }}</option>
             {{ end }}
           </select>
         </div>

--- a/app/views/miniblog/posts/update.html
+++ b/app/views/miniblog/posts/update.html
@@ -12,6 +12,20 @@
         <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="body">Content (markdown compatible)</label>
         <textarea class="focus:shadow-outline w-full appearance-none rounded border px-3 py-2 leading-tight text-gray-700 shadow focus:outline-none" rows="12" id="body" name="body" placeholder="Your awesome thought...">{{ .Post.Body }} </textarea>
       </div>
+      <div class="flex">
+        <div class="mb-4 w-1/2">
+          <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="visibility">Visibility</label>
+          <select name="visibility" id="visibility">
+            {{ range .visibilityOptions }}
+            <option value="{{ .ID }}">{{ .Name }}</option>
+            {{ end }}
+          </select>
+        </div>
+        <div class="mb-4 w-1/2">
+          <label class="mb-2 block text-sm font-bold text-gray-700 dark:text-amber-400" for="publish_status">Publish on Mastodon?</label>
+          <input type="checkbox" id="publish_status" name="publish_status" />
+        </div>
+      </div>
       <div class="flex items-center justify-between">
         <button class="rounded-md bg-amber-500 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-amber-400 focus:outline-none dark:text-slate-900" type="submit">Edit</button>
       </div>

--- a/app/views/miniblog/posts/update.html
+++ b/app/views/miniblog/posts/update.html
@@ -1,6 +1,6 @@
-<div class="relative rounded-xl bg-white p-8 drop-shadow dark:bg-slate-900">
+<div class="relative -mx-4 bg-white drop-shadow dark:bg-slate-900 md:rounded-xl md:p-8">
   <div class="w-full">
-    <form class="" action="/miniblog/{{ .User.NickNameURL }}/posts/{{ .Post.ID }}/edit" method="post">
+    <form class="mb-4 px-8 pb-8 pt-6" action="/miniblog/{{ .User.NickNameURL }}/posts/{{ .Post.ID }}/edit" method="post">
       <div class="order-3 mb-2 block grow text-center text-4xl font-bold dark:text-amber-400 md:order-2 md:inline">
         <h1>Edit</h1>
       </div>

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,11 @@ require (
 require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 )
 
 require (
@@ -39,6 +41,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-mastodon v0.0.6
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.25
 	github.com/muesli/reflow v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+
 github.com/gorilla/sessions v1.1.1/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -178,6 +180,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-mastodon v0.0.6 h1:lqU1sOeeIapaDsDUL6udDZIzMb2Wqapo347VZlaOzf0=
+github.com/mattn/go-mastodon v0.0.6/go.mod h1:cg7RFk2pcUfHZw/IvKe1FUzmlq5KnLFqs7eV2PHplV8=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -218,6 +222,8 @@ github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gt
 github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.47.0 h1:y7moDoxYzMooFpT5aHgNgVOQDrS3qlkfiP9mDtGGK9c=

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 			fmt.Sprintf("%s/auth/mastodon/callback", os.Getenv("APP_BASE_URL")),
 			fmt.Sprintf("%s", os.Getenv("MASTODON_URL")),
 			"read:accounts",
+			"write:statuses",
 		),
 	)
 


### PR DESCRIPTION
This PR is adding multiple features around post visibility:
- The user can set the visibility of the blog post (public, unlisted, private)
  - Only public blog posts will get listed in the "Latest posts" section
- The user can publish automatically a toot announcing their new post
- The user can publish on edit a toot announcing their new post
- The user can change the visibility of a post

<img width="1347" alt="image" src="https://github.com/3615-computer/portal/assets/2109178/3d08905c-66d3-4fb8-91ce-e171ab325e29">
